### PR TITLE
[Update] deploy.yml 스탭 실행조건 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-and-deploy:
@@ -49,6 +52,7 @@ jobs:
 
       # 5. AWS 인증 설정 (IAM 사용자 키 기반)
       - name: Configure AWS credentials
+        if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}  # GitHub Secrets에서 가져온 액세스 키
@@ -57,16 +61,19 @@ jobs:
 
       # 6. AWS ECR에 로그인
       - name: Login to Amazon ECR
+        if: github.event_name == 'push'
         uses: aws-actions/amazon-ecr-login@v2
 
       # 7. Docker 이미지 빌드 & ECR에 푸시
       - name: Build & Push Docker image
+        if: github.event_name == 'push'
         run: |
           docker build --platform linux/amd64 --provenance=false -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       # 8. ECS Task Definition을 수정하여 최신 이미지 반영
       - name: Render ECS task definition
+        if: github.event_name == 'push'
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: ecs/task-definition.json  # 사전 정의된 JSON 템플릿 경로
@@ -75,9 +82,10 @@ jobs:
 
       # 9. ECS 서비스에 새 Task Definition 적용 → 무중단 롤링 배포 수행
       - name: Deploy to ECS
+        if: github.event_name == 'push'
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ecs/task-definition.json  # 앞 단계에서 렌더링된 Task Definition
           cluster: monew-cluster  # 배포 대상 ECS 클러스터
           service: monew-service  # 배포 대상 ECS 서비스
-          wait-for-service-stability: true  
+          wait-for-service-stability: true


### PR DESCRIPTION
현재 yml 파일의 steps 항목은 pull_request와 push 이벤트에 따라 분리되어 있습니다.

- PR 생성 시에는 다음 스텝만 실행됩니다:

- GitHub 저장소 코드 체크아웃

- JDK 17 설치 (Gradle 빌드를 위해 필요)

- gradlew 실행 권한 부여

- 테스트 실행 및 Jacoco 코드 커버리지 측정

- 커버리지 리포트를 Codecov에 업로드

PR이 승인되고 main 브랜치에 머지되었을 때 (push)에는 위 테스트를 포함해 Docker 빌드, ECR 업로드, ECS 배포 등 전체 스텝이 모두 실행됩니다.

또한 PR 생성 시에도 커버리지 측정을 수행하고, 머지 이후에 다시 테스트 및 커버리지 검사를 반복하는 이유는,
PR 생성 이후 다른 PR이 먼저 머지되며 main 브랜치의 상태가 변경되었을 수 있기 때문입니다.
따라서 최신 main 브랜치 기준으로 다시 테스트하여 최종 배포 전 검증을 강화하기 위함입니다.