### PR TITLE
feat: Mongodb 수정을 위해 deploy.yml 수정, dockerfile 복구

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      # 2. JDK 17 설정
+     # 2. JDK 17 설정
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -61,8 +61,8 @@ jobs:
           echo "DB_URL=${{ secrets.DB_URL_DEV }}" >> $GITHUB_ENV
           echo "DB_USERNAME=${{ secrets.DB_USERNAME_DEV }}" >> $GITHUB_ENV
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD_DEV }}" >> $GITHUB_ENV
-          echo "MONGO_URI=${{ secrets.MONGO_URI }}" >> $GITHUB_ENV
           echo "SPRING_PROFILES_ACTIVE=dev" >> $GITHUB_ENV
+          echo "MONGO_URI=${{ secrets.MONGO_URI }}" >> $GITHUB_ENV
 
       # main 브랜치의 시크릿을 env에 설정
       - name: Set DB Secrets for PROD
@@ -71,8 +71,8 @@ jobs:
           echo "DB_URL=${{ secrets.DB_URL_PROD }}" >> $GITHUB_ENV
           echo "DB_USERNAME=${{ secrets.DB_USERNAME_PROD }}" >> $GITHUB_ENV
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD_PROD }}" >> $GITHUB_ENV
-          echo "MONGO_URI=${{ secrets.MONGO_URI }}" >> $GITHUB_ENV
           echo "SPRING_PROFILES_ACTIVE=prod" >> $GITHUB_ENV
+          echo "MONGO_URI=${{ secrets.MONGO_URI }}" >> $GITHUB_ENV
 
       # 6-1. AWS 인증 (운영)
       - name: Configure AWS credentials (PROD)
@@ -101,15 +101,8 @@ jobs:
       - name: Build & Push Docker image
         if: github.event_name == 'push'
         run: |
-          docker build \
-            --platform linux/amd64 \
-            --provenance=false \
-            --build-arg AWS_ACCESS_KEY_ID=${{ secrets.AWS_S3_ACCESS_KEY_ID }} \
-            --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_S3_SECRET_ACCESS_KEY }} \
-            --build-arg AWS_REGION=${{ secrets.AWS_REGION }} \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --platform linux/amd64 --provenance=false -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
 
       # 9. Task Definition 렌더링
       - name: Render ECS task definition
@@ -124,8 +117,8 @@ jobs:
             DB_URL=${{ env.DB_URL }}
             DB_USERNAME=${{ env.DB_USERNAME }}
             DB_PASSWORD=${{ env.DB_PASSWORD }}
-            MONGO_URI=${{ env.MONGO_URI }}
             SPRING_PROFILES_ACTIVE=${{ env.SPRING_PROFILES_ACTIVE }}
+            MONGO_URI=${{ env.MONGO_URI }}
 
       # 10. ECS 서비스에 새 Task 적용
       - name: Deploy to ECS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,67 +1,21 @@
 # -----------------------------
-# 1단계: Gradle 빌드 단계
+# 1단계: Build Stage
 # -----------------------------
 FROM gradle:7.6.1-jdk17 AS build
-
-# 작업 디렉토리 설정
 WORKDIR /home/gradle/project
-
-# 소스 코드 복사
 COPY . .
 
-# gradle 빌드 실행 (테스트 제외)
+# 권한 주고 gradlew로 빌드
 RUN chmod +x ./gradlew && ./gradlew clean build -x test --no-daemon
 
-
 # -----------------------------
-# 2단계: 인증서 다운로드 및 truststore 등록 단계
-# -----------------------------
-FROM amazoncorretto:17.0.7-alpine AS cert
-
-# 작업 디렉토리 설정
-WORKDIR /tmp
-
-# AWS CLI 설치
-RUN apk add --no-cache curl unzip && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install && \
-    ln -s /usr/local/bin/aws /usr/bin/aws
-
-# Docker build 시 전달받을 AWS 인증 정보
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ARG AWS_REGION
-
-# 환경 변수로 설정하여 aws cli가 사용할 수 있도록 함
-ENV AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-    AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-    AWS_REGION=$AWS_REGION
-
-# S3에서 인증서 다운로드 후 JVM truststore에 등록
-RUN aws s3 cp s3://monew-s3/global-bundle.pem /etc/ssl/certs/ && \
-    keytool -import -trustcacerts -alias aws-docdb \
-    -file /etc/ssl/certs/global-bundle.pem \
-    -keystore $JAVA_HOME/lib/security/cacerts \
-    -storepass changeit -noprompt
-
-
-# -----------------------------
-# 3단계: 최종 실행 이미지 구성 단계
+# 2단계: Runtime Stage
 # -----------------------------
 FROM amazoncorretto:17.0.7-alpine
-
-# 애플리케이션 실행 디렉토리 설정
 WORKDIR /app
 
-# 인증서 등록된 truststore 파일 복사
-COPY --from=cert $JAVA_HOME/lib/security/cacerts $JAVA_HOME/lib/security/cacerts
-
-# 빌드된 JAR 파일 복사
 COPY --from=build /home/gradle/project/build/libs/monew.jar monew.jar
 
-# 컨테이너 포트 오픈
 EXPOSE 8080
 
-# Spring Boot 앱 실행 명령
 CMD ["java", "-jar", "monew.jar"]


### PR DESCRIPTION
이번 PR에서는 기존에 AWS DocumentDB를 시도하던 방식을 EC2 인스턴스에 직접 MongoDB를 설치하여 사용하는 방식으로 변경하였습니다.
MongoDB는 EC2 내부에 설치 후, mongod.conf 설정을 통해 외부 접속이 가능하도록 bindIp를 수정하고, 인증 기능을 활성화하였습니다.

Spring Boot 애플리케이션에서는 MongoDB 연결 정보를 MONGO_URI 환경 변수로 분리하였으며, 해당 값은 GitHub Actions 워크플로우에서 등록된 시크릿 키를 통해 주입되도록 구성하였습니다.
프로젝트 내 application-*.yml 파일에서는 해당 환경 변수를 참조하여 MongoDB에 접근합니다.

로컬 및 EC2 환경에서는 MongoDB 접속 및 인증이 정상적으로 동작하는 것을 확인하였으며, 최종적으로는 실제 배포된 ECS Task의 로그를 통해 MongoDB 연결 여부를 확인할 예정입니다.