### PR TITLE
뉴스 수집 배치 수정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,6 +3,13 @@ spring:
     activate:
       on-profile: dev
 
+  sql:
+    init:
+      mode: always # 자동으로 스키마 초기화 스크립트를 실행
+      continue-on-error: true # 실행 도중에 “테이블이 이미 존재한다” 같은 SQL 오류가 발생해도, 애플리케이션 기동을 중단하지 않고 계속 진행
+      schema-locations: # 실제로 실행할 스키마(DDL) 파일 경로 목록
+        - classpath:org/springframework/batch/core/schema-postgresql.sql
+
   jpa:
     hibernate:
       ddl-auto: none
@@ -26,6 +33,8 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+    software.amazon.awssdk: DEBUG # AWS SDK의 코어 기능(인증, 시그니처 생성, 리트라이 전략, 인터셉터 등) 전반에 걸친 디버그 로그
+    software.amazon.awssdk.http: DEBUG # HTTP 클라이언트(요청·응답 전송) 레벨의 디버그 로그
 
 management:
   endpoint:
@@ -56,5 +65,7 @@ rss:
       url: https://news-ex.jtbc.co.kr/v1/get/rss/issue
 
 cron:
-  news : "0 0 * * * *" #매시간
-  backup : "0 0 0 * * *" #매일
+  news: "0 * * * * *"   # 10분마다
+  backup: "0 0 0 * * *"   # 정각
+
+


### PR DESCRIPTION
- dev.yml 
  - 배치를 위한 스크립트 추가
  - aws s3 백업을 위한 log debug 추가
 
- 코드 구현
  - 스케줄링, 백업 로그 추가
  - 배치 job  Prameter 중복으로 인한 오류 해결

- 테스트를 위해 뉴스 배치 작업 10분으로 줄임(기존 1시간 -> 10분 마다 연동)